### PR TITLE
Fix main

### DIFF
--- a/src/targets/sample_embunit/AllTests.c
+++ b/src/targets/sample_embunit/AllTests.c
@@ -3,7 +3,7 @@
 TestRef CounterTest_tests(void);
 TestRef PersonTest_tests(void);
 
-int main (int argc, const char* argv[])
+int main (int argc, char* argv[])
 {
 	TestRunner_start();
 		TestRunner_runTest(CounterTest_tests());


### PR DESCRIPTION
規格上サポートされることが保証されるのは、`argv` の型は `char **` (と等価な型) にした時だけです (組み込みの事情でしたら申し訳ありません)。